### PR TITLE
add ShiftGenerator by rule base

### DIFF
--- a/app/shift_generator/shift_generator.rb
+++ b/app/shift_generator/shift_generator.rb
@@ -63,16 +63,17 @@ class ShiftGenerator
     return true
   end
 
-  # 出勤時間をuser[:array]に格納する。
-  # TODO この処理をしなくて済むようにする or user[:array]にアタッチするのをやめる。
+  # 出勤時間をuser[:attend_array]に格納する。
+  # TODO この処理をしなくて済むようにする or user[:attend_array]にアタッチするのをやめる。
   def attendance_method
     p " 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23 :時刻"
     @users.each do |user|
-      user[:array] = convert_attendance_to_array(
+      user[:attend_array] = convert_attendance_to_array(
+        user[:id],
         string2hour(user[:attendance_at]).to_i, 
         string2hour(user[:leaving_at]).to_i
       )
-      p "#{user[:array]}:#{user[:name]}の出勤時間"
+      p "#{user[:attend_array][:array]}:#{user[:name]}の出勤時間"
     end
     p "#{@req}:必要リソース"
   end
@@ -81,23 +82,20 @@ class ShiftGenerator
   # leaving_at: "2019-11-16 22:00:00",
   # 上記フォーマットを配列に変換する。
   # [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]
-  def convert_attendance_to_array(attend,leave)
+  def convert_attendance_to_array(id,attend,leave)
     array = [ 0 ] * DATE_TIME
     flag = false
     array.each_with_index do |data, i|
-      if i == attend
-        flag = true
-      elsif i == leave
-        flag = false
-      end 
+      flag = true if i == attend
+      flag = false if i == leave
       array[i] = flag ? 1 : 0
     end
-    array
+    {user_id: id, array: array}
   end
 
   # 出勤しているユーザから必要リソース人数抽出する。
   def find_assign_users(req,i)
-    assign_user = @users.map{|user| user if user[:array][i] == 1 }
+    assign_user = @users.map{|user| user if user[:attend_array][:array][i] == 1 }
     assign_user.compact.sample(req) # compactメソッドは、配列からnilを削除 # sampleメソッドは、配列からランダムで引数の数取り出す。
   end
 

--- a/app/shift_generator/shift_generator.rb
+++ b/app/shift_generator/shift_generator.rb
@@ -1,0 +1,137 @@
+class ShiftGenerator
+  DATE_TIME = 24
+  def initialize()
+    @users = import_user
+    # 必要リソースを定義する
+    # TODO @req(必要リソース)はテーブルからとってくる。
+    @req = [ 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 1 , 1 , 2 , 2 , 2 , 2 , 2 , 2 , 3 , 2 , 2 , 1 , 0 , 0 ] #0時〜23時
+    # @sum(確定シフトの合計)
+    @shift_sum = [ 0 ] * DATE_TIME
+  end
+
+  def parseTohour(time)
+    Time.zone.parse(time).strftime("%H").to_i
+  end
+
+  def parseTohourmin(time)
+    Time.zone.parse(time).strftime("%H:%M").to_i
+  end
+
+  # 3人のユーザを作成する 
+  # 後にUserモデルからとってくる。
+  def import_user
+    @users = [
+      { 
+        id: 1,
+        name: "John",
+        attendance_at: "2019-11-16 10:00:00",
+        leaving_at: "2019-11-16 20:00:00",
+        shift_in_at: nil,
+        shift_out_at: nil
+      },
+      { 
+        id: 2,
+        name: "Kevin",
+        attendance_at: "2019-11-16 12:00:00",
+        leaving_at: "2019-11-16 22:00:00",
+        shift_in_at: nil,
+        shift_out_at: nil
+      },
+      { 
+        id: 3,
+        name: "Cacy",
+        attendance_at: "2019-11-16 18:00:00",
+        leaving_at: "2019-11-16 22:00:00",
+        shift_in_at: nil,
+        shift_out_at: nil
+      }
+    ]
+  end
+    
+  # チェックテストメソッド　必要リソース == 確定シフトの合計となっていること
+  def check
+    DATE_TIME.times do |i| 
+      return false if @req[i] != @shift_sum[i] 
+    end
+    return true
+  end
+
+  # 出勤時間をuser[:array]に格納する。
+  # TODO この処理をしなくて済むようにする or user[:array]にアタッチするのをやめる。
+  def attendance_method
+    @users.each do |user|
+      user[:array] = convertPeriod(parseTohour(user[:attendance_at]), parseTohour(user[:leaving_at]))
+      p user[:array]
+    end
+    p @req
+  end
+
+  # attendance_at: "2019-11-16 12:00:00",
+  # leaving_at: "2019-11-16 22:00:00",
+  # 上記フォーマットを配列に変換する。
+  # [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]
+  def convertPeriod(attend,leave)
+    array = [ 0 ] * DATE_TIME
+    flag = false
+    array.each_with_index do |data, i|
+      if i == attend
+        flag = true
+      elsif i == leave
+        flag = false
+      end 
+      array[i] = flag ? 1 : 0
+    end
+    array
+  end
+
+  # 出勤しているユーザから必要リソース人数抽出する。
+  def find_assign_users(req,i)
+    assign_user = []
+    @users.each do |user|
+      if user[:array][i] == 1
+        assign_user << user
+      end
+    end
+    assign_user.sample(req) # sampleメソッドは、配列からランダムで引数の数取り出す。
+  end
+
+  # シフト生成メソッド(シフトのルールベースから生成する)
+  def generate_by_rule_base
+    @req.each_with_index do |req,i|
+      if req > @shift_sum[i]
+        assign_user = find_assign_users(req, i)
+        assign_user.each do |user|
+          if user[:shift_in_at] == nil
+            user[:shift_in_at] = Time.zone.strptime((i).to_s, '%H')
+            user[:shift_out_at] = Time.zone.strptime((i+1).to_s, '%H')
+          else
+            user[:shift_out_at] = Time.zone.strptime((i+1).to_s, '%H')
+          end
+        end
+        @shift_sum[i] += assign_user.length 
+      end
+    end
+    p @shift_sum 
+  end
+
+  # 各ユーザのシフトを表示する。
+  def display_shift
+    line = "---------------"
+    @users.each do |user|
+      p line
+      p "◇#{user[:name]}さんの出勤"
+      p "#{parseTohour(user[:attendance_at])}〜#{parseTohour(user[:leaving_at])}"
+      p "◇#{user[:name]}さんのシフト"
+      p "#{parseTohourmin(user[:shift_in_at])}〜#{parseTohourmin(user[:shift_out_at])}"
+    end
+    p line
+  end
+
+  # ShiftGenerator.main
+  def main
+    attendance_method # 出勤時間を配列に格納する。
+    generate_by_rule_base
+    p check ? "シフト完了" : "シフト失敗"
+    display_shift
+  end
+end

--- a/app/shift_generator/shift_generator.rb
+++ b/app/shift_generator/shift_generator.rb
@@ -9,12 +9,19 @@ class ShiftGenerator
     @shift_sum = [ 0 ] * DATE_TIME
   end
 
-  def parseTohour(time)
-    Time.zone.parse(time).strftime("%H").to_i
+  # "2019-11-16 10:00:00" => "10"
+  def string2hour(time)
+    Time.zone.parse(time).strftime("%H")
   end
 
-  def parseTohourmin(time)
-    Time.zone.parse(time).strftime("%H:%M").to_i
+  # "2019-11-16 10:00:00" => "10:00"
+  def string2hourmin(time)
+    Time.zone.parse(time).strftime("%H:%M")
+  end
+
+  #  "Sat, 07 Dec 2019 10:00:00 UTC +00:00" => "10:00"
+  def time2hourmin(time)
+    time.strftime("%H:%M")
   end
 
   # 3人のユーザを作成する 
@@ -59,11 +66,15 @@ class ShiftGenerator
   # 出勤時間をuser[:array]に格納する。
   # TODO この処理をしなくて済むようにする or user[:array]にアタッチするのをやめる。
   def attendance_method
+    p " 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23 :時刻"
     @users.each do |user|
-      user[:array] = convertPeriod(parseTohour(user[:attendance_at]), parseTohour(user[:leaving_at]))
-      p user[:array]
+      user[:array] = convertPeriod(
+        string2hour(user[:attendance_at]).to_i, 
+        string2hour(user[:leaving_at]).to_i
+      )
+      p "#{user[:array]}:#{user[:name]}の出勤時間"
     end
-    p @req
+    p "#{@req}:必要リソース"
   end
 
   # attendance_at: "2019-11-16 12:00:00",
@@ -102,16 +113,16 @@ class ShiftGenerator
         assign_user = find_assign_users(req, i)
         assign_user.each do |user|
           if user[:shift_in_at] == nil
-            user[:shift_in_at] = Time.zone.strptime((i).to_s, '%H')
-            user[:shift_out_at] = Time.zone.strptime((i+1).to_s, '%H')
+            user[:shift_in_at] = Time.zone.strptime(("#{i}:00").to_s, '%H:%M')
+            user[:shift_out_at] = Time.zone.strptime(("#{i+1}:00").to_s, '%H:%M')
           else
-            user[:shift_out_at] = Time.zone.strptime((i+1).to_s, '%H')
+            user[:shift_out_at] = Time.zone.strptime(("#{i+1}:00").to_s, '%H:%M')
           end
         end
         @shift_sum[i] += assign_user.length 
       end
     end
-    p @shift_sum 
+    p "#{@shift_sum}:合計リソース" 
   end
 
   # 各ユーザのシフトを表示する。
@@ -120,9 +131,9 @@ class ShiftGenerator
     @users.each do |user|
       p line
       p "◇#{user[:name]}さんの出勤"
-      p "#{parseTohour(user[:attendance_at])}〜#{parseTohour(user[:leaving_at])}"
+      p "#{string2hourmin(user[:attendance_at])}〜#{string2hourmin(user[:leaving_at])}"
       p "◇#{user[:name]}さんのシフト"
-      p "#{parseTohourmin(user[:shift_in_at])}〜#{parseTohourmin(user[:shift_out_at])}"
+      p "#{time2hourmin(user[:shift_in_at])}〜#{time2hourmin(user[:shift_out_at])}"
     end
     p line
   end


### PR DESCRIPTION
# What
シフト生成アルゴリズムのたたき台を作りました。
- ユーザの仮定義
- 最小のアルゴリズム作成

# Why
- なぜこの変更をするのか
シフト生成アルゴリズム自体が、大きく範囲が見えないため、
最小の実装としてたたき台を作る必要があるため

# 影響範囲
- ユーザへの影響(メリット・デメリット)
特になし
- 開発側への影響(メリット・デメリット)
アルゴリズムをクラスとして作成しました。
作成場所がわからなかったので、とりあえず以下に保存しています。
[![Image from Gyazo](https://i.gyazo.com/a1ae881ac1f759b57421c1e0a9e294b3.png)](https://gyazo.com/a1ae881ac1f759b57421c1e0a9e294b3)
適切な場所に保存し直す必要があります。

# 関連URL
- 参考URL
active_supportのTimeWithZoneクラスのメソッドを多用しました。
https://github.com/rails/rails/blob/09a2979f75c51afb797dd60261a8930f84144af8/activesupport/lib/active_support/time_with_zone.rb
- 画像URL

# 使い方、確認の仕方、テストの仕方
- 使い方の説明
rails cでShiftGeneratorクラスのインスタンスを生成します。
mainメソッドを実行します。
- 再現手順等 
```
rails c
s = ShiftGenerator.new
s.main
```
- 出力
```
" 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23 :時刻"
"[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]:Johnの出勤時間"
"[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]:Kevinの出勤時間"
"[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0]:Cacyの出勤時間"
"[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2, 3, 2, 2, 1, 0, 0]:必要リソース"
"[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2, 3, 2, 2, 1, 0, 0]:合計リソース"
"シフト完了"
"---------------"
"◇Johnさんの出勤"
"10:00〜20:00"
"◇Johnさんのシフト"
"10:00〜19:00"
"---------------"
"◇Kevinさんの出勤"
"12:00〜22:00"
"◇Kevinさんのシフト"
"12:00〜22:00"
"---------------"
"◇Cacyさんの出勤"
"18:00〜22:00"
"◇Cacyさんのシフト"
"18:00〜21:00"
"---------------"
```

# 注意事項
- 注意
"2019-11-16 10:00:00"のような時間を変換するため、active_supportの読み込み環境下が必要です。

## 目視確認
- [ ] テストする際の項目を、このように、チェック可能な形式で記載する。

# TODOと保留
- TODO
  - @req(必要リソース)はテーブルからとってくる。
  - 出勤時間をuser[:array]に格納するのをしないようにする
  - user[:array]に出勤時間をアタッチするのをやめる。
- 保留項目
  - デバッグの出力を削除すること

# その他
