### PR TITLE
downgrade sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+gem 'sassc'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-gem 'sassc'
+gem 'sassc', '2.1.0'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       railties (>= 4.2.0)
     faker (2.1.2)
       i18n (>= 0.8)
-    ffi (1.11.1)
+    ffi (1.11.3)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
@@ -291,7 +291,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.2.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -380,7 +380,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rspec-rails
   sass-rails (~> 5.0)
-  sassc
+  sassc (= 2.1.0)
   selenium-webdriver
   shoulda-matchers
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,6 +380,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rspec-rails
   sass-rails (~> 5.0)
+  sassc
   selenium-webdriver
   shoulda-matchers
   spring


### PR DESCRIPTION
# What
- なにをどう変更したか
sasscのバージョンを2.1.0で指定しました。
# Why
- なぜこの変更をするのか
sassc 2.2.1が本番環境への導入で失敗するため

- 何が問題となっているのか
```
00:16 bundler:install
      01 $HOME/.rbenv/bin/rbenv exec bundle install --path /var/www/tech_visual/shared/bundle --jobs 4 --without development test --deployment --quiet
      01 Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
      01
      01 current directory:
      01 /var/www/tech_visual/shared/bundle/ruby/2.5.0/gems/sassc-2.2.1/ext
      01 /home/ec2-user/.rbenv/versions/2.5.1/bin/ruby -r
      01 ./siteconf20191209-18537-r5qovs.rb extconf.rb
      01 creating Makefile
      01
      01 current directory:
      01 /var/www/tech_visual/shared/bundle/ruby/2.5.0/gems/sassc-2.2.1/ext
      01 make "DESTDIR=" clean
      01
      01 current directory:
      01 /var/www/tech_visual/shared/bundle/ruby/2.5.0/gems/sassc-2.2.1/ext
      01 make "DESTDIR="
      01 compiling ./libsass/src/cencode.c
      01 compiling ./libsass/src/c99func.c
      01 compiling ./libsass/src/node.cpp
      01 compiling ./libsass/src/util.cpp
      01 compiling ./libsass/src/fn_maps.cpp
      01 compiling ./libsass/src/inspect.cpp
      01 compiling ./libsass/src/position.cpp
      01 compiling ./libsass/src/plugins.cpp
      01 compiling ./libsass/src/ast.cpp
      01 compiling ./libsass/src/ast_fwd_decl.cpp
      01 compiling ./libsass/src/sass_values.cpp
      01 compiling ./libsass/src/parser.cpp
      01 compiling ./libsass/src/context.cpp
      01 compiling ./libsass/src/base64vlq.cpp
      01 compiling ./libsass/src/fn_utils.cpp
      01 compiling ./libsass/src/ast_supports.cpp
      01 compiling ./libsass/src/to_value.cpp
      01 compiling ./libsass/src/utf8_string.cpp
      01 compiling ./libsass/src/sass_context.cpp
      01 compiling ./libsass/src/sass_util.cpp
      01 compiling ./libsass/src/ast_sel_unify.cpp
      01 compiling ./libsass/src/fn_strings.cpp
      01 compiling ./libsass/src/color_maps.cpp
      01 compiling ./libsass/src/bind.cpp
      01 compiling ./libsass/src/ast_sel_cmp.cpp
      01 compiling ./libsass/src/expand.cpp
      01 compiling ./libsass/src/sass2scss.cpp
      01 compiling ./libsass/src/prelexer.cpp
      01 compiling ./libsass/src/ast_selectors.cpp
      01 compiling ./libsass/src/ast_values.cpp
      01 compiling ./libsass/src/fn_miscs.cpp
      01 compiling ./libsass/src/memory/SharedPtr.cpp
      01 compiling ./libsass/src/environment.cpp
      01 compiling ./libsass/src/fn_lists.cpp
      01 compiling ./libsass/src/sass_functions.cpp
      01 compiling ./libsass/src/remove_placeholders.cpp
      01 compiling ./libsass/src/subset_map.cpp
      01 compiling ./libsass/src/extend.cpp
      01 compiling ./libsass/src/error_handling.cpp
      01 compiling ./libsass/src/check_nesting.cpp
      01 compiling ./libsass/src/ast2c.cpp
      01 compiling ./libsass/src/fn_colors.cpp
      01 compiling ./libsass/src/util_string.cpp
      01 compiling ./libsass/src/source_map.cpp
      01 compiling ./libsass/src/output.cpp
      01 compiling ./libsass/src/emitter.cpp
      01 compiling ./libsass/src/listize.cpp
      01 compiling ./libsass/src/c2ast.cpp
      01 compiling ./libsass/src/backtrace.cpp
      01 compiling ./libsass/src/constants.cpp
      01 compiling ./libsass/src/lexer.cpp
      01 compiling ./libsass/src/json.cpp
      01 compiling ./libsass/src/fn_selectors.cpp
      01 compiling ./libsass/src/operators.cpp
      01 compiling ./libsass/src/sass.cpp
      01 compiling ./libsass/src/values.cpp
      01 compiling ./libsass/src/cssize.cpp
      01 compiling ./libsass/src/fn_numbers.cpp
      01 compiling ./libsass/src/units.cpp
      01 compiling ./libsass/src/eval.cpp
      01 compiling ./libsass/src/file.cpp
      01 linking shared-object sassc/libsass.so
      01 lto1: fatal error: LTO_tags out of range: Range is 0 to 365, value is 2566
      01 compilation terminated.
      01 lto-wrapper: g++ returned 1 exit status
      01 /usr/bin/ld: lto-wrapper failed
      01 collect2: error: ld returned 1 exit status
      01 make: *** [libsass.so] エラー 1
      01
      01 make failed, exit code 2
      01
      01 Gem files will remain installed in
      01 /var/www/tech_visual/shared/bundle/ruby/2.5.0/gems/sassc-2.2.1 for inspection.
      01 Results logged to
      01 /var/www/tech_visual/shared/bundle/ruby/2.5.0/extensions/x86_64-linux/2.5.0-static/sassc-2.2.1/gem_make.out
      01
      01 An error occurred while installing sassc (2.2.1), and Bundler cannot continue.
      01 Make sure that `gem install sassc -v '2.2.1' --source 'https://rubygems.org/'`
      01 succeeds before bundling.
      01
      01 In Gemfile:
      01   activeadmin was resolved to 2.4.0, which depends on
      01     sassc-rails was resolved to 2.1.2, which depends on
      01       sassc

```

# 現在の状況
**sassc 2.1.0で問題なくデプロイできました。**

# 影響範囲
- 開発側への影響(メリット・デメリット)
sasscが2.1.0になりました。
