### PR TITLE
Add shift generate button

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,6 +1,11 @@
 ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 
+  # title_barの右側に新しいアクションを追加する
+  action_item :shift_generate, only: :index do
+    link_to "シフト作成", api_shift_generator_path, method: :post
+  end
+
   content title: proc { I18n.t("active_admin.dashboard") } do
     div class: "blank_slate_container", id: "dashboard_default_message" do
       span class: "blank_slate" do

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -2,17 +2,20 @@ ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 
   # title_barの右側に新しいアクションを追加する
-  action_item :shift_generate, only: :index do
-    link_to "シフト作成", api_shift_generator_path, method: :post
-  end
+  # action_item :shift_generate, only: :index do
+  #   link_to "シフト作成", api_shift_generator_path, method: :post
+  # end
 
   content title: proc { I18n.t("active_admin.dashboard") } do
-    div class: "blank_slate_container", id: "dashboard_default_message" do
-      span class: "blank_slate" do
-        span I18n.t("active_admin.dashboard_welcome.welcome")
-        small I18n.t("active_admin.dashboard_welcome.call_to_action")
-      end
-    end
+    # admin/dash_board/_indexを呼び出す
+    render partial: 'index'
+
+    # div class: "blank_slate_container", id: "dashboard_default_message" do
+    #   span class: "blank_slate" do
+    #     span I18n.t("active_admin.dashboard_welcome.welcome")
+    #     small I18n.t("active_admin.dashboard_welcome.call_to_action")
+    #   end
+    # end
 
     # Here is an example of a simple dashboard with columns and panels.
     #

--- a/app/controllers/api/shift_generator_controller.rb
+++ b/app/controllers/api/shift_generator_controller.rb
@@ -1,0 +1,4 @@
+class Api::ShiftGeneratorController < ApplicationController
+  def create
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,7 +16,7 @@ class Ability
       can :manage, :all
     end
 
-    if user.member?
+    if user.employee?
       # CheckBoxモデルをcreateできない
       # can :create, CheckBox
       # 自分のCheckBoxモデルはupdateできる

--- a/app/views/admin/dashboard/_index.html.erb
+++ b/app/views/admin/dashboard/_index.html.erb
@@ -1,0 +1,7 @@
+<%= form_with url: api_shift_generator_path, local: true do |f| %>
+  <div class='shift_gen'>
+    <%= f.date_field :start %>
+    <%= f.date_field :finish %>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,8 @@ Rails.application.routes.draw do
   devise_for :users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    post 'shift_generator' => 'shift_generator#create'
+  end
 end


### PR DESCRIPTION
# What
- ダッシュボードのviewにシフト作成ボタンを追加しました。
- 仮置きで`api/shift_generator#create`というアクションを動かすようにしています。

# Why
- 1クリックでシフト自動生成を実行するためのボタンが必要であるため。

# 影響範囲
- ユーザー、開発共に特に無し

# 使い方、確認の仕方、テストの仕方
- app/admin/dashboard.rb の`action_item`というオプションが本機能の実装箇所です。
  - link_to の書き方はRailsのヘルパーと同一です。
  - ルーティング、コントローラーは仮置きな
ので必要であれば作り変えて上記`link_to`のパスを変えて下さい

# テスト結果とテスト項目
## テストコード実装済み
- 仮置きのAPIであるため、テストコードは実装していません。

## 目視確認
以下のように想定通りにbinding.pryに到達することで動作確認しました。
![add_shift_button](https://user-images.githubusercontent.com/43090220/70903148-9734bb80-2041-11ea-8969-884be20cf917.gif)
