### PR TITLE
[WIP]Add judge what_day method

### DIFF
--- a/app/models/required_resource.rb
+++ b/app/models/required_resource.rb
@@ -2,9 +2,23 @@ class RequiredResource < ApplicationRecord
   # associations
   belongs_to :work_role
 
-  # enums
-  enum what_day: { weekday: 1, holiday: 2, kick_off_weekday: 3, kick_off_holiday: 4 }
-
   # validates
   validates :what_day, :clock_at, :count, presence: true
+  validates :what_day, numericality: { greater_than_or_equal_to: 1,
+                                       less_than_or_equal_to: 14 }
+  validates :clock_at, numericality: { greater_than_or_equal_to: 0,
+                                       less_than_or_equal_to: 23 }
+
+  def self.on_(this_day)
+    first_week_case = [8,9,10,11,12,13,14,15,23,24,25,26,27,28,29,30] # 今週の土曜がこの日付なら今日は1週目
+    dif_of_wday_what_day = 2 # wdayとキックオフ後日数との差。例えば日曜はwday=0、キックオフ2日目。
+    this_sat = this_day - (this_day.wday - 6).days
+    what_day = if first_week_case.include?(this_sat.day)
+                 this_day.wday + dif_of_wday_what_day
+               else
+                 # 2週目の土曜は15日目と計算されてしまうため、その場合は1(次のキックオフ当日)とする
+                 this_day == this_sat ? 1 : this_day.wday + dif_of_wday_what_day + 7
+               end
+    where(what_day: what_day)
+  end
 end

--- a/app/models/work_role.rb
+++ b/app/models/work_role.rb
@@ -1,6 +1,6 @@
 class WorkRole < ApplicationRecord
   # associations
-  has_many :required_resources
+  has_many :required_resources, dependent: :destroy
   has_many :shifts
 
   # validates

--- a/spec/factories/required_resources.rb
+++ b/spec/factories/required_resources.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :required_resource do
-    
+    what_day {Faker::Number.within(range: 1..14)}
+    clock_at {Faker::Number.within(range: 0..23)}
+    count    {Faker::Number.within(range: 1..15)}
+    work_role
   end
 end

--- a/spec/factories/work_roles.rb
+++ b/spec/factories/work_roles.rb
@@ -1,5 +1,21 @@
 FactoryBot.define do
   factory :work_role do
-    
+    name {Faker::Job.title}
+
+    trait :with_all_required_resources do
+      after(:build) do |wr|
+        what_days = 1..14
+        clocks = 0..23
+        what_days.each do |wd|
+          clocks.each do |clock_at|
+            create(:required_resource,
+              what_day: wd,
+              clock_at: clock_at,
+              work_role: wr
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/required_resource_spec.rb
+++ b/spec/models/required_resource_spec.rb
@@ -1,8 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe RequiredResource, type: :model do
-  it { is_expected.to belong_to(:work_role) }
-  it { is_expected.to define_enum_for(:what_day) }
-  it { is_expected.to validate_presence_of :clock_at }
-  it { is_expected.to validate_presence_of :count }
+  describe 'validation' do
+    it { is_expected.to belong_to(:work_role) }
+    it { is_expected.to validate_presence_of :what_day }
+    it { is_expected.to validate_numericality_of(:what_day)
+      .is_greater_than_or_equal_to(1).is_less_than_or_equal_to(14) }
+    it { is_expected.to validate_presence_of :clock_at }
+    it { is_expected.to validate_numericality_of(:clock_at)
+      .is_greater_than_or_equal_to(0).is_less_than_or_equal_to(23) }
+    it { is_expected.to validate_presence_of :count }
+  end
+
+  describe 'methods' do
+    context 'self.on_', on_: true do
+      before(:all) { build(:work_role, :with_all_required_resources) }
+      after(:all) { WorkRole.destroy_all }
+      let(:default_counts) { 24 }
+
+      it '第1キックオフ当日のレコードを正しく取得できる' do
+        create(:required_resource, what_day: 1)
+        test_records = RequiredResource.on_(Time.new(2019,12,7))
+        expect(test_records.length).to eq default_counts + 1
+      end
+
+      it '第1キックオフ翌日のレコードを正しく取得できる' do
+        create(:required_resource, what_day: 2)
+        test_records = RequiredResource.on_(Time.new(2019,12,8))
+        expect(test_records.length).to eq default_counts + 1
+      end
+
+      it '第1キックオフから7日目のレコードを正しく取得できる' do
+        create(:required_resource, what_day: 7)
+        test_records = RequiredResource.on_(Time.new(2019,12,13))
+        expect(test_records.length).to eq default_counts + 1
+      end
+
+      it '第1キックオフから8日目のレコードを正しく取得できる' do
+        create(:required_resource, what_day: 8)
+        test_records = RequiredResource.on_(Time.new(2019,12,14))
+        expect(test_records.length).to eq default_counts + 1
+      end
+
+      it '第1キックオフから14日目のレコードを正しく取得できる' do
+        create(:required_resource, what_day: 14)
+        test_records = RequiredResource.on_(Time.new(2019,12,20))
+        expect(test_records.length).to eq default_counts + 1
+      end
+
+      it '第2キックオフ当日のレコードを正しく取得できる' do
+        create(:required_resource, what_day: 1)
+        test_records = RequiredResource.on_(Time.new(2019,12,21))
+        expect(test_records.length).to eq default_counts + 1
+      end
+
+      it '第2キックオフ翌日のレコードを正しく取得できる' do
+        create(:required_resource, what_day: 2)
+        test_records = RequiredResource.on_(Time.new(2019,12,22))
+        expect(test_records.length).to eq default_counts + 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What
- 日付を引数にキックオフから何日目かを割り出す`RequiredResource.on_()`メソッドを実装した

# Why
- 特定の日付の必要リソースを取得できるようにするため

# (WIP) 
予定に無いタスクで変更点多いため、PRと次回スプリントレビューで認識を合わせたいです。
## 意見求む
- RequiredResourceモデルのwhat_dayカラムからenumを削除しましが問題無いでしょうか？
  - キックオフから何日目かを計算した後にわざわざ粒度の粗い区分へ変換する意味が無いため。
  - DB設計の段階で、将来的に14日分に分けるべきだと認識していたので問題無いと判断しました。
- テストを書いてて気付いたのですが14日分 * 時間ごと(24)で**WorkRole1つあたり336件のレコードが必要です。**
  - 30分、15分ごとにすることを見据えるとさらに倍々に・・
  - what_dayごとに 00_00, 01_00, 02_00 みたいなカラムで人数を持つ設計の方が良い？
    - 正規化的には思いっきり後退してる気がする。
- **前月に第5土曜日がある場合、本来15~21日目となりますが対応していません**
  - 8~14日目(2週目)として表示されます。
    - 1週空く＝必要リソースは減るはずなので大きな問題は無い？
  - そこまで細かく必要リソースを考えるならむしろ前月だけでは足りないので保留にしたい。

## WIPが外れる条件
- いつ
  - 12/21のレビュー前後。
- どういう結果が得られたら
  - 設計に関して認識合わせができたら。

# 影響範囲
- ユーザへの影響(メリット・デメリット)
- 開発側への影響(メリット・デメリット)
- その他コードへの影響

# 関連URL
- 参考URL
- 画像URL

# 大きな仕様変更
- before
- after

# 使い方、確認の仕方、テストの仕方
- 使い方の説明
- 再現手順等 

# 注意事項
- 注意

# テスト結果とテスト項目
## テストコード実装済み
- [x] 第1キックオフ当日のレコードを正しく取得できる
- [x] 第1キックオフ翌日のレコードを正しく取得できる
- [x] 第1キックオフから7日目のレコードを正しく取得できる
- [x] 第1キックオフから8日目のレコードを正しく取得できる
- [x] 第1キックオフから14日目のレコードを正しく取得できる
- [x] 第2キックオフ当日のレコードを正しく取得できる
- [x] 第2キックオフ翌日のレコードを正しく取得できる
![RR_test](https://user-images.githubusercontent.com/43090220/70908331-4bd4da00-204e-11ea-8b5c-d00064a7d609.jpg)


# TODOと保留
- TODO
- 保留項目

# その他
