### PR TITLE
Restore shift generate button

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,10 +1,6 @@
 ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 
-  # title_barの右側に新しいアクションを追加する
-  # action_item :shift_generate, only: :index do
-  #   link_to "シフト作成", api_shift_generator_path, method: :post
-  # end
 
   content title: proc { I18n.t("active_admin.dashboard") } do
     # admin/dash_board/_indexを呼び出す

--- a/app/admin/shifts.rb
+++ b/app/admin/shifts.rb
@@ -6,6 +6,11 @@ ActiveAdmin.register Shift do
   filter :shift_in_at
   filter :shift_out_at
 
+  # title_barの右側に新しいアクションを追加する
+  action_item :shift_generate, only: :index do
+    link_to "シフト作成", api_shift_generator_path, method: :post if current_user.admin?
+  end
+
   controller do
     def index
       redirect_to new_user_session_path and return unless user_signed_in?


### PR DESCRIPTION
# What
- adminユーザーでログインした際に、shifts#indexにシフト作成ボタンを追加した

# Why
- なぜこの変更をするのか
  - シフト作成ボタンを一時的に削除していたので復旧しました。

# 影響範囲
- ユーザへの影響(メリット・デメリット)
- 開発側への影響(メリット・デメリット)
  - admin権限のユーザーでログインした状態でshifts#indexにアクセスするとタイトルバーにシフト生成ボタンが出現します。
- その他コードへの影響

# TODOと保留
- TODO
  - 各機能がどのアクションで動くのか、documentを更新する必要がある。
- 保留項目
