### PR TITLE
move shift generate button to shifts#index for admin

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,11 +1,6 @@
 ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 
-  # title_barの右側に新しいアクションを追加する
-  # action_item :shift_generate, only: :index do
-  #   link_to "シフト作成", api_shift_generator_path, method: :post
-  # end
-
   content title: proc { I18n.t("active_admin.dashboard") } do
     # admin/dash_board/_indexを呼び出す
     render partial: 'index'

--- a/app/admin/shifts.rb
+++ b/app/admin/shifts.rb
@@ -17,6 +17,8 @@ ActiveAdmin.register Shift do
   index do
     if user_signed_in?.nil? || current_user.employee?
       render partial: 'index'
+    else
+      render partial: 'admin_index'
     end
   end
 end

--- a/app/views/admin/shifts/_admin_index.html.haml
+++ b/app/views/admin/shifts/_admin_index.html.haml
@@ -1,0 +1,5 @@
+= form_with url: api_shift_generator_path, local: true do |f|
+  .shift_gen
+    = f.date_field :start
+    = f.date_field :finish
+    = f.submit

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -146,7 +146,7 @@ ActiveAdmin.setup do |config|
   #
   # Enable and disable Batch Actions
   #
-  config.batch_actions = true
+  config.batch_actions = false
 
   # == Controller Filters
   #


### PR DESCRIPTION
# What
- シフト生成ボタンを削除していたため、admin用のshifts#indexに作成しました。

# Why
- なぜこの変更をするのか
  - shifts#indexから期間の入力を受け取ってシフト作成を行うため
- 何が問題となっているのか
- ユーザの操作をどう改善したいのか

# 影響範囲
- ユーザへの影響(メリット・デメリット)
- 開発側への影響(メリット・デメリット)
  - admin権限(role=1のユーザー)でログインしないと使えないのでご注意下さい。
- その他コードへの影響

# TODOと保留
- TODO
  - 各機能がどのコントローラのどのアクションで動くのかを整理する必要がある
- 保留項目
