### PR TITLE
Change color per workrole

### DIFF
--- a/app/assets/javascripts/shift_data_color.js
+++ b/app/assets/javascripts/shift_data_color.js
@@ -12,23 +12,23 @@ $(function(){
 
     // 指定された長さの、カラーコードが格納された配列を返す。
     function setColorArray(len){
-      let array = [];
+      const array = [];
       for (let i=0; i<len; i++) {
         array.push(randomColor());
       }
       return array;
     }
 
-    let workrole_ids = $(".shift-tables").data("workrole-ids");
-    let color_array = setColorArray(workrole_ids.length);
+    const workrole_ids = $(".shift-tables").data("workrole-ids");
+    const color_array = setColorArray(workrole_ids.length);
       
     // 色クラスが付いているところは該当の色を割り当てる
     $(".color_shift-data").each(function(){
-      let workrole_id = $( this ).data("workrole-id");
-      let nth = $.inArray(workrole_id, workrole_ids);
-      let color = color_array[nth];
+      const workrole_id = $( this ).data("workrole-id");
+      const nth = $.inArray(workrole_id, workrole_ids);
+      const color = color_array[nth];
 
-      let styles = {
+      const styles = {
         backgroundColor : color,
         border : `1px solid ${color}`,
         borderBottom : `1px solid #dee2e6`

--- a/app/assets/javascripts/shift_data_color.js
+++ b/app/assets/javascripts/shift_data_color.js
@@ -14,7 +14,7 @@ $(function(){
     function setColorArray(len){
       let array = [];
       for (let i=0; i<len; i++) {
-        array.push(randomColor())
+        array.push(randomColor());
       }
       return array;
     }

--- a/app/assets/javascripts/shift_data_color.js
+++ b/app/assets/javascripts/shift_data_color.js
@@ -1,0 +1,39 @@
+$(function(){
+  // 画面にshift-tableが存在したら
+  $(".shift-tables").ready(function(){
+    // 16進数のランダムなカラーコードを生成する
+    function randomColor(){
+      let colorCode = "#";
+      for(let i = 0; i < 6; i++) {
+        colorCode += (16*Math.random() | 0).toString(16);
+      }
+      return colorCode;
+    }
+
+    // 指定された長さの、カラーコードが格納された配列を返す。
+    function setColorArray(len){
+      let array = [];
+      for (let i=0; i<len; i++) {
+        array.push(randomColor())
+      }
+      return array;
+    }
+
+    let workrole_ids = $(".shift-tables").data("workrole-ids");
+    let color_array = setColorArray(workrole_ids.length);
+      
+    // 色クラスが付いているところは該当の色を割り当てる
+    $(".color_shift-data").each(function(){
+      let workrole_id = $( this ).data("workrole-id");
+      let nth = $.inArray(workrole_id, workrole_ids);
+      let color = color_array[nth];
+
+      let styles = {
+        backgroundColor : color,
+        border : `1px solid ${color}`,
+        borderBottom : `1px solid #dee2e6`
+      };
+      $( this ).css(styles);
+    });
+  });
+})

--- a/app/assets/stylesheets/module/shift_table.scss
+++ b/app/assets/stylesheets/module/shift_table.scss
@@ -19,11 +19,5 @@
       text-align: left;
       background:white;
     }
-
-    tr td.blue{
-      background:#4372de;
-      border: 1px solid #4372de;
-      border-bottom: 1px solid #dee2e6; 
-    }
   }
 }

--- a/app/controllers/api/shift_generator_controller.rb
+++ b/app/controllers/api/shift_generator_controller.rb
@@ -4,6 +4,7 @@ class Api::ShiftGeneratorController < ApplicationController
     workroles = WorkRole.all
     s = ShiftGenerator.new(users, workroles)
     @result = s.generate(period_params)
+    @workrole_ids = workroles.map(&:id)
   end
 
   private

--- a/app/controllers/api/shift_generator_controller.rb
+++ b/app/controllers/api/shift_generator_controller.rb
@@ -4,7 +4,6 @@ class Api::ShiftGeneratorController < ApplicationController
     workroles = WorkRole.all
     s = ShiftGenerator.new(users, workroles)
     @result = s.generate(period_params)
-    @workrole_ids = workroles.map(&:id)
   end
 
   private

--- a/app/views/api/shift_generator/create.html.haml
+++ b/app/views/api/shift_generator/create.html.haml
@@ -1,6 +1,6 @@
 %section.shift_api_create_page
   %h1.page_title シフト一覧
-  .shift-tables.shift-slick_container{data: {workrole: {ids: @workrole_ids}}}
+  .shift-tables.shift-slick_container{data: {workrole: {ids: WorkRole.ids}}}
     - (DateTime.parse(@period[:start])..DateTime.parse(@period[:finish])).each do |this_day|
       .shift-table
         %h

--- a/app/views/api/shift_generator/create.html.haml
+++ b/app/views/api/shift_generator/create.html.haml
@@ -1,6 +1,6 @@
 %section.shift_api_create_page
   %h1.page_title シフト一覧
-  .shift-tables.shift-slick_container
+  .shift-tables.shift-slick_container{data: {workrole: {ids: @workrole_ids}}}
     - (DateTime.parse(@period[:start])..DateTime.parse(@period[:finish])).each do |this_day|
       .shift-table
         %h
@@ -23,7 +23,7 @@
                 - shift_time_to_array(shift).each_with_index do |is_shift, i|
                   - if i >= 8 && i <= 24
                     - if is_shift
-                      %td.blue
+                      %td.color_shift-data{data: {workrole: {id: shift.work_role.id}}}
                     - else
                       %td
                   - else


### PR DESCRIPTION
# What
- シフトを画面表示する際、workroleの項目ごとに色分けする
- workrole毎にランダムな色が割り当てられるようになりました！

# Why
- どのworkroleにアサインされたのか確認できるようにするため。

# 影響範囲
特になし

# 関連URL
- 画像URL
[![Screenshot from Gyazo](https://gyazo.com/e078ed868b1b50a43a699bf3b53761c4/raw)](https://gyazo.com/e078ed868b1b50a43a699bf3b53761c4)
- 参考URL
https://q-az.net/random-color-code/

# テスト結果とテスト項目
## テストコード実装済み
- [x] テストする際の項目を、このように、チェック可能な形式で記載する。

## 目視確認
- [ ] テストする際の項目を、このように、チェック可能な形式で記載する。
```
Finished in 1.62 seconds (files took 5.4 seconds to load)
32 examples, 0 failures
```
# TODOと保留
- TODO
- 保留項目
ランダムな色が出てくるので、色がダサい

# その他
