### PR TITLE
fix multiple workrole assign bug

### DIFF
--- a/app/models/shift_generator.rb
+++ b/app/models/shift_generator.rb
@@ -52,12 +52,19 @@ class ShiftGenerator
       if req > sum[time]
         find_assign_users(this_day, time, req, attendances).map do |user_id|
           shift_instance = shift_array.map { |shift| shift if shift.user_id == user_id}
-          shift_instance = shift_instance.compact[0]
+          shift_instance = shift_instance.compact.last
           if shift_instance.shift_in_at.nil?
             shift_instance.shift_in_at = Time.zone.strptime(this_day.to_s,"%Y-%m-%d").change(hour: time)
             shift_instance.shift_out_at = Time.zone.strptime(this_day.to_s,"%Y-%m-%d").change(hour: time+1)
-          else
+          elsif shift_instance.shift_out_at.strftime('%H').to_i == time
             shift_instance.shift_out_at = Time.zone.strptime(this_day.to_s,"%Y-%m-%d").change(hour: time+1)
+          else
+            shift_array << Shift.new(
+              user_id: user_id,
+              work_role_id: workrole.id,
+              shift_in_at: Time.zone.strptime(this_day.to_s,"%Y-%m-%d").change(hour: time),
+              shift_out_at: Time.zone.strptime(this_day.to_s,"%Y-%m-%d").change(hour: time+1)
+            )
           end
           sum[time] += 1
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,5 @@ class User < ApplicationRecord
 
   # validates
   validates :name, :role, presence: true
+  validates :name, uniqueness: true
 end

--- a/app/views/api/shift_generator/create.html.haml
+++ b/app/views/api/shift_generator/create.html.haml
@@ -15,16 +15,17 @@
               - else
                 %th.hidden
                   = d
-          - @result[:shift].each do |shift|
-            - if this_day.strftime("%Y/%m/%d") == shift[:shift_in_at].strftime("%Y/%m/%d")
-              %tr
-                %td 
-                  = shift.user.name
-                - shift_time_to_array(shift).each_with_index do |is_shift, i|
-                  - if i >= 8 && i <= 24
-                    - if is_shift
-                      %td.color_shift-data{data: {workrole: {id: shift.work_role.id}}}
+          - User.all.each do |user|
+            - @result[:shift].each do |shift|
+              - if user.id == shift[:user_id] && this_day.strftime("%Y/%m/%d") == shift[:shift_in_at].strftime("%Y/%m/%d")
+                %tr
+                  %td 
+                    = user.name
+                  - shift_time_to_array(shift).each_with_index do |is_shift, i|
+                    - if i >= 8 && i <= 24
+                      - if is_shift
+                        %td.color_shift-data{data: {workrole: {id: shift.work_role.id}}}
+                      - else
+                        %td
                     - else
-                      %td
-                  - else
-                    %td.hidden
+                      %td.hidden

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,20 +18,22 @@ attendances = []
     email: Faker::Internet.free_email,
     password: Faker::Internet.password(min_length: 8)
   )
-
-  time_array = [rand(23),rand(23)].sort
-  (start..finish).each do |this_day|
-    attendances << Attendance.new(date: this_day, attendance_at: time_array[0], leaving_at: time_array[1],user_id: user.id)
+  if user.persisted?
+    (start..finish).each do |this_day|
+      time_array = [rand(24),rand(24)].sort
+      attendances << Attendance.new(date: this_day, attendance_at: time_array[0], leaving_at: time_array[1],user_id: user.id)
+    end
   end
 end
+
 Attendance.import! attendances
 
 requiredresources = []
 4.times do |n|
   workrole = WorkRole.create!(name: Faker::Company.name)
-  req = ([0] * 23).map{ |x| rand(10) }.sort.rotate(rand(23)) #0時〜23時
-  req.each_with_index do |data, i|
-    (start..finish).each do |this_day|
+  (start..finish).each do |this_day|
+    req = ([0] * 23).map{ |x| rand(10) }.sort.rotate(rand(23)) #0時〜23時
+    req.each_with_index do |data, i|
       requiredresources << RequiredResource.new(what_day: RequiredResource.on_(this_day), clock_at: i, count: data ,work_role_id: workrole.id)
     end
   end


### PR DESCRIPTION
# What
- 複数のWorkroleにシフトインしてしまうのを解消した。
- Userモデルのnameに一意性制約をつけた
# Why
- 何が問題となっているのか
複数のWorkroleにシフトインするシフトが生成されてしまう。

# 原因
### 原因①
Fakerで同じユーザ名のユーザが複数作成されていた。
よって、同じ時間に複数のシフトインしているように見えていた。

### 原因②
シフトインが途切れているとき、shift_out_atを書き換えることで、
シフトインを一直線にするロジックになっていた。

例)

| (理想)Johnのシフト| 1   |  2   |3|4|5|
| :------------- | :-- | :-----| :--|:--|:--|
| Workrole1      |　  |      |in|  out ||
| Workrole2      | in|  in | out  |in|out|

| (バグ)Johnのシフト| 1   |  2   |3|4|5|
| :------------- | :-- | :-----| :--|:--|:--|
| Workrole1      |　  |      |in| out  ||
| Workrole2      | in|  | ||out|


```
if shift_instance.shift_in_at.nil?
  shift_instance.shift_in_at = Time.zone.strptime(this_day.to_s,"%Y-%m-%d").change(hour: time)
  shift_instance.shift_out_at = Time.zone.strptime(this_day.to_s,"%Y-%m-%d").change(hour: time+1)
else
  shift_instance.shift_out_at = Time.zone.strptime(this_day.to_s,"%Y-%m-%d").change(hour: time+1)
end
```
元々は`shift_instance.shift_in_at.nil?`シフトがすでに存在していたらshift_out_atを無条件で書き換えるロジックになっていたので、シフトが途切れているデータに対応できていなかった。

# 影響範囲
- ユーザへの影響(メリット・デメリット)
- 開発側への影響(メリット・デメリット)
- その他コードへの影響

# 関連URL
- 参考URL
- 画像URL
[![Screenshot from Gyazo](https://gyazo.com/8091416748a61662fd09ca146cd77f5f/raw)](https://gyazo.com/8091416748a61662fd09ca146cd77f5f)
# 大きな仕様変更
- before
Userモデルのnameが被っても良い
- after
**Userモデルのnameに一意性制約をつけたい**

# 使い方、確認の仕方、テストの仕方
- 使い方の説明
- 再現手順等 

# 注意事項
- 注意

# テスト結果とテスト項目
## テストコード実装済み
- [x] テストする際の項目を、このように、チェック可能な形式で記載する。

## 目視確認
- [ ] テストする際の項目を、このように、チェック可能な形式で記載する。

# TODOと保留
- TODO
- 保留項目
ユーザに紐づいている複数のシフトを１行で表示すること
# その他
