### PR TITLE
Create employee shifts index

### DIFF
--- a/app/admin/shifts.rb
+++ b/app/admin/shifts.rb
@@ -2,13 +2,16 @@ ActiveAdmin.register Shift do
   permit_params :work_role_id, :user_id, :shift_in_at, :shift_out_at
 
   filter :user
-  filter :work_role
-  filter :shift_in_at
-  filter :shift_out_at
 
   controller do
     def index
       redirect_to new_user_session_path and return unless user_signed_in?
+      first_day = DateTime.now.beginning_of_month
+      @days = []
+      DateTime.now.end_of_month.day.times do |day|
+        @days << first_day
+        first_day += 1.days
+      end
       super
     end
   end

--- a/app/assets/stylesheets/admin/shifts/_index.scss
+++ b/app/assets/stylesheets/admin/shifts/_index.scss
@@ -1,0 +1,5 @@
+.employee-shifts {
+  @include shift_color_sample();
+
+  @include shift_table_style();
+}

--- a/app/assets/stylesheets/api/shift_generator/create.scss
+++ b/app/assets/stylesheets/api/shift_generator/create.scss
@@ -1,21 +1,14 @@
 .shift_api_create_page{
   width: 90%;
   margin: 0 auto;
-  
+
   .page_title{
     margin: 50px 0;
     font-size: 24px;
   }
-  .workrole-example_lists{
-    display: flex;
-    margin: 30px 0px;
-    justify-content: space-around;
-    width: 100%;
-    li{
-      padding: 10px;
-      color: white;
-    }
-  }
+
+  @include shift_color_sample();
+
   .shift-tables{
     .shift-table{
       @include shift_table_style();

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,8 +3,10 @@
 @import 'config/common';
 
 // module
+@import 'module/shift_color_sample';
 @import 'module/shift_table';
 
 // page style
 @import 'api/shift_generator/create';
 @import 'admin/dashboard/index';
+@import 'admin/shifts/index';

--- a/app/assets/stylesheets/module/_shift_color_sample.scss
+++ b/app/assets/stylesheets/module/_shift_color_sample.scss
@@ -1,0 +1,12 @@
+@mixin shift_color_sample() {
+  .workrole-example_lists{
+    display: flex;
+    margin: 30px 0px;
+    justify-content: space-around;
+    width: 100%;
+    li{
+      padding: 10px;
+      color: white;
+    }
+  }
+}

--- a/app/assets/stylesheets/module/shift_table.scss
+++ b/app/assets/stylesheets/module/shift_table.scss
@@ -2,11 +2,11 @@
   table{
     width: 100%;
     text-align: center;
-    border: 1px solid #dee2e6; 
+    border: 1px solid #dee2e6;
     td, th{
       padding: 0.75em;
       text-align: center;
-      border: 1px solid #dee2e6; 
+      border: 1px solid #dee2e6;
     }
     td{
       background:#ced9f2;
@@ -14,12 +14,12 @@
     tr:nth-child(odd) td{
       background: #eff2f7;
     }
-    
+
     tr td:nth-of-type(1){
       text-align: left;
       background:white;
     }
-    
+
     .shift-table__resource{
       .title{
         font-weight: bold;

--- a/app/views/admin/shifts/_index.html.haml
+++ b/app/views/admin/shifts/_index.html.haml
@@ -1,20 +1,28 @@
-.table
-  = current_user.name
-  .date-axis
-    - (Settings.Attendance_time + 1).times do |num|
-      - if num == 0
-        .time-cell
-      - else
-        .time-cell
-          = num + 9
-          \:00
-  / ユーザーの仮置き
-  - Time.current.end_of_month.day.times do |num|
-    .name-axis
-      .cell
-        / 日付
-        = display_day_and_wday(Time.new(2019, 12, num+1))
-      .worktime
-        - Settings.Attendance_time.times do |attendance|
-          .worktime-cell
-
+%section.employee-shifts.shift-tables{data: {workrole: {ids: WorkRole.ids}}}
+  %h1.page_title #{current_user.name}さんの今月のシフト
+  %ul.workrole-example_lists
+    - WorkRole.all.each do |workrole|
+      %li.color_shift-data{data: {workrole: {id: workrole.id}}}
+        = workrole.name
+  %table
+    %tr
+      %th
+      - [*0..23].each do |d|
+        - if d >= 8 && d <= 24
+          %th
+            = d
+        - else
+          %th.hidden
+            = d
+    - @days.each do |day|
+      %tr
+        %td
+          = day.strftime('%Y %m %d')
+        - shifts_to_one_array(current_user.shifts.on_thisday(day)).each_with_index do |is_shift, i|
+          - if i >= 8 && i <= 24
+            - if is_shift
+              %td.color_shift-data{data: {workrole: {id: is_shift}}}
+            - else
+              %td
+          - else
+            %td.hidden


### PR DESCRIPTION
# What
- なにをどう変更したか
  - 一般社員の権限でshifts#indexにアクセスした際、自分の今月のシフトが表示されるようにした。

# Why
- なぜこの変更をするのか
  - ユーザーのマイページに当たる機能として必須であるため。
- 何が問題となっているのか
- ユーザの操作をどう改善したいのか

# 関連URL
- 画像URL
![employee_shifts](https://user-images.githubusercontent.com/43090220/73542042-32111a00-4477-11ea-88d9-45197025a516.jpg)

# 大きな仕様変更
- before
- after

# 使い方、確認の仕方、テストの仕方
- 使い方の説明
- 再現手順等 

# 注意事項
- 注意

# テスト結果とテスト項目
## テストコード実装済み
- [x] テストする際の項目を、このように、チェック可能な形式で記載する。

## 目視確認
- [ ] テストする際の項目を、このように、チェック可能な形式で記載する。

# TODOと保留
- TODO
- 保留項目

# その他
