### PR TITLE
Add shifts build from genoms method

### DIFF
--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -22,32 +22,34 @@ class Shift < ApplicationRecord
     def build_from_genoms(genoms)
       # 返り値に使うShiftインスタンス格納用配列
       shift_instances = []
-      genoms[:shifts].each do |shift|
-        # shiftsからuser_idを拾い、nilを除外する
-        shift_info = { user_id: shift[:user_id] }
-        shift[:array].each_with_index { |ele, i| shift_info[i] = ele if ele }
-        # シフトイン時間算出用の変数
-        hour = 0
-        shift_info.each_with_object({}).each_with_index do |(obj), i|
-          # 初回はuser_idなのでスキップ
-          next if i == 0
-          if obj[1] == shift_info[obj[0]+1] # 今のworkroleと次のworkroleが一緒だったら
-            hour += 1
-          else # それ以外、つまりシフトイン時間が確定したら
-            # work_role_id=0 は学習時間のため、変数を初期化して次へ
-            hour = 0 and next if obj[1] == 0
-            # 確定情報からシフトインスタンスに必要な情報を作成
-            hour += 1
-            day = genoms[:this_day].to_date
-            shift_attributes = {
-              user_id: shift_info[:user_id],
-              work_role_id: obj[1],
-              shift_in_at: "#{day} #{obj[0] + 1 - hour}:00:00",
-              shift_out_at: "#{day} #{obj[0] + 1}:00:00",
-            }
-            # シフトイン時間を初期化
-            hour = 0
-            shift_instances << Shift.new(shift_attributes)
+      genoms.each do |genom|
+        genom[:shifts].each do |shift|
+          # shiftsからuser_idを拾い、nilを除外する
+          shift_info = { user_id: shift[:user_id] }
+          shift[:array].each_with_index { |ele, i| shift_info[i] = ele if ele }
+          # シフトイン時間算出用の変数
+          hour = 0
+          shift_info.each_with_object({}).each_with_index do |(obj), i|
+            # 初回はuser_idなのでスキップ
+            next if i == 0
+            if obj[1] == shift_info[obj[0]+1] # 今のworkroleと次のworkroleが一緒だったら
+              hour += 1
+            else # それ以外、つまりシフトイン時間が確定したら
+              # work_role_id=0 は学習時間のため、変数を初期化して次へ
+              hour = 0 and next if obj[1] == 0
+              # 確定情報からシフトインスタンスに必要な情報を作成
+              hour += 1
+              day = genom[:this_day].to_date
+              shift_attributes = {
+                user_id: shift_info[:user_id],
+                work_role_id: obj[1],
+                shift_in_at: "#{day} #{obj[0] + 1 - hour}:00:00",
+                shift_out_at: "#{day} #{obj[0] + 1}:00:00",
+              }
+              # シフトイン時間を初期化
+              hour = 0
+              shift_instances << Shift.new(shift_attributes)
+            end
           end
         end
       end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -11,9 +11,47 @@ class Shift < ApplicationRecord
   # validates
   validates :shift_in_at, :shift_out_at, presence: true
 
-  def self.find_user_shift(user, this_day, shifts = Shift.all)
-    shifts.map do |shift|
-      shift if user.id == shift[:user_id] && this_day.strftime('%Y/%m/%d') == shift[:shift_in_at].strftime('%Y/%m/%d')
-    end.compact!
+  class << self
+
+    def find_user_shift(user, this_day, shifts = Shift.all)
+      shifts.map do |shift|
+        shift if user.id == shift[:user_id] && this_day.strftime('%Y/%m/%d') == shift[:shift_in_at].strftime('%Y/%m/%d')
+      end.compact!
+    end
+
+    def build_from_genoms(genoms)
+      # 返り値に使うShiftインスタンス格納用配列
+      shift_instances = []
+      genoms[:shifts].each do |shift|
+        # shiftsからuser_idを拾い、nilを除外する
+        shift_info = { user_id: shift[:user_id] }
+        shift[:array].each_with_index { |ele, i| shift_info[i] = ele if ele }
+        # シフトイン時間算出用の変数
+        hour = 0
+        shift_info.each_with_object({}).each_with_index do |(obj), i|
+          # 初回はuser_idなのでスキップ
+          next if i == 0
+          if obj[1] == shift_info[obj[0]+1] # 今のworkroleと次のworkroleが一緒だったら
+            hour += 1
+          else # それ以外、つまりシフトイン時間が確定したら
+            # work_role_id=0 は学習時間のため、変数を初期化して次へ
+            hour = 0 and next if obj[1] == 0
+            # 確定情報からシフトインスタンスに必要な情報を作成
+            hour += 1
+            day = genoms[:this_day].to_date
+            shift_attributes = {
+              user_id: shift_info[:user_id],
+              work_role_id: obj[1],
+              shift_in_at: "#{day} #{obj[0] + 1 - hour}:00:00",
+              shift_out_at: "#{day} #{obj[0] + 1}:00:00",
+            }
+            # シフトイン時間を初期化
+            hour = 0
+            shift_instances << Shift.new(shift_attributes)
+          end
+        end
+      end
+      shift_instances
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :user do
-    
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    password { Devise.friendly_token }
+    role { 'employee' }
   end
 end

--- a/spec/factories/work_roles.rb
+++ b/spec/factories/work_roles.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :work_role do
+    sequence(:id) { |n| n }
     name {Faker::Job.title}
 
     trait :with_all_required_resources do

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -1,8 +1,63 @@
 require 'rails_helper'
 
 RSpec.describe Shift, type: :model do
-  it { is_expected.to belong_to(:user) }
-  it { is_expected.to belong_to(:work_role) }
-  it { is_expected.to validate_presence_of :shift_in_at }
-  it { is_expected.to validate_presence_of :shift_out_at }
+  describe 'validation' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:work_role) }
+    it { is_expected.to validate_presence_of :shift_in_at }
+    it { is_expected.to validate_presence_of :shift_out_at }
+  end
+
+  describe 'methods' do
+    context 'self.build_from_genoms' do
+      let(:user) { create(:user) }
+      let(:work_roles) { create_list(:work_role, 4) }
+      let(:genoms) {{
+        this_day: "Wed, 01 Jan 2020 00:00:00 +0000",
+        shifts: [
+          user_id: user.id,
+          array: [nil, nil, nil, nil, nil, nil, 3, 2, 2, 2, 1, 2, 4, 0, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil]
+        ]
+      }}
+
+      it '想定しているシフトの件数(6件)と一致している' do
+        shifts = Shift.build_from_genoms(genoms)
+        expect(shifts.length).to eq 6
+      end
+
+      it '最初のシフトが想定通りの値になっている' do
+        shifts = Shift.build_from_genoms(genoms)
+        valid_shift_attributes = Shift.new(
+          user_id: user.id,
+          work_role_id: 3,
+          shift_in_at: DateTime.new(2020, 1, 1, 6),
+          shift_out_at: DateTime.new(2020, 1, 1, 7)
+        ).attributes
+        expect(shifts[0].attributes).to eq valid_shift_attributes
+      end
+
+      it '2番目のシフトが想定通りの値になっている' do
+        shifts = Shift.build_from_genoms(genoms)
+        valid_shift_attributes = Shift.new(
+          user_id: user.id,
+          work_role_id: 2,
+          shift_in_at: DateTime.new(2020, 1, 1, 7),
+          shift_out_at: DateTime.new(2020, 1, 1, 10)
+        ).attributes
+        expect(shifts[1].attributes).to eq valid_shift_attributes
+      end
+
+      it '最後のシフトが想定通りの値になっている' do
+        shifts = Shift.build_from_genoms(genoms)
+        valid_shift_attributes = Shift.new(
+          user_id: user.id,
+          work_role_id: 1,
+          shift_in_at: DateTime.new(2020, 1, 1, 14),
+          shift_out_at: DateTime.new(2020, 1, 1, 16)
+        ).attributes
+        expect(shifts[-1].attributes).to eq valid_shift_attributes
+      end
+
+    end
+  end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Shift, type: :model do
       let(:user) { create(:user) }
       let(:work_roles) { create_list(:work_role, 4) }
       let(:genoms) {[{
-        this_day: "Wed, 01 Jan 2020 00:00:00 +0000",
+        this_day: DateTime.new(2020, 1, 1),
         shifts: [
           user_id: user.id,
           array: [nil, nil, nil, nil, nil, nil, 3, 2, 2, 2, 1, 2, 4, 0, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil]

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Shift, type: :model do
     context 'self.build_from_genoms' do
       let(:user) { create(:user) }
       let(:work_roles) { create_list(:work_role, 4) }
-      let(:genoms) {{
+      let(:genoms) {[{
         this_day: "Wed, 01 Jan 2020 00:00:00 +0000",
         shifts: [
           user_id: user.id,
           array: [nil, nil, nil, nil, nil, nil, 3, 2, 2, 2, 1, 2, 4, 0, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil]
         ]
-      }}
+      }]}
 
       it '想定しているシフトの件数(6件)と一致している' do
         shifts = Shift.build_from_genoms(genoms)


### PR DESCRIPTION
# What
- なにをどう変更したか
  - Shiftモデルにgenomsを受け取ってインスタンスを作成するメソッドを実装した。

# Why
- なぜこの変更をするのか
  - シフト生成アルゴリズムが、インスタンスを生成して返すのではなくシフト作成に必要な情報をハッシュで返すように仕様変更予定である。
  - よって最終的に受け取る情報(genoms)を元にShiftモデルのインスタンスを作成する仕組みが必要であるため実装した。
- 何が問題となっているのか
- ユーザの操作をどう改善したいのか

# 影響範囲
- ユーザへの影響(メリット・デメリット)
- 開発側への影響(メリット・デメリット)
- その他コードへの影響

# 関連URL
- 参考URL
- 画像URL

# 大きな仕様変更
- before
- after

# 使い方、確認の仕方、テストの仕方
- 使い方の説明
- 再現手順等 

# 注意事項
- 注意

# テスト結果とテスト項目
## テストコード実装済み
- [x] 想定しているシフトの件数(6件)と一致している。
- [x] 最初のシフトが想定通りの値になっている。
- [x] 2番目のシフトが想定通りの値になっている。
- [x] 最後のシフトが想定通りの値になっている。

## 目視確認
- [ ] テストする際の項目を、このように、チェック可能な形式で記載する。

# TODOと保留
- TODO
- 保留項目

# その他
