### PR TITLE
Add edit genoms api

### DIFF
--- a/app/assets/javascripts/shift_data_color.js
+++ b/app/assets/javascripts/shift_data_color.js
@@ -18,21 +18,57 @@ $(function(){
       return array;
     }
 
-    const workrole_ids = $(".shift-tables").data("workrole-ids");
-    const color_array = setColorArray(workrole_ids.length);
-
-    // 色クラスが付いているところは該当の色を割り当てる
-    $(".color_shift-data").each(function(){
-      const workrole_id = $( this ).data("workrole-id");
+    // 色変え関数
+    function changeWorkRoleColer(cell) {
+      // jQueryのdata()はキャッシュされるためJSのdatasetを使う
+      const workrole_id = Number(cell[0].dataset.workroleId);
+      if (workrole_id === 0) {
+        cell.removeAttr('style')
+        return;
+      }
       const nth = $.inArray(workrole_id, workrole_ids);
       const color = color_array[nth];
-
       const styles = {
         backgroundColor : color,
         border : `1px solid ${color}`,
         borderBottom : `1px solid #dee2e6`
       };
-      $( this ).css(styles);
+      cell.css(styles);
+    }
+
+    const workrole_ids = $(".shift-tables").data("workrole-ids");
+    const color_array = setColorArray(workrole_ids.length);
+
+    // 色クラスが付いているところは該当の色を割り当てる
+    $(".color_shift-data").each(function(){
+      changeWorkRoleColer($(this));
+    });
+
+    $(document).on('click', 'td.color_shift-data', function(){
+      // doneで操作するli要素を取得しておく
+      const targetCell = $(this);
+      const workroleId = this.dataset.workroleId;
+      const genomIndex = $(this).data('genom-index');
+      const shiftIndex = $(this).data('shift-index');
+      const shiftInAt = $(this).data('shift-in-at');
+      $.ajax({
+        url: `/api/shift_generator`,
+        type: 'put',
+        data: {
+          genom_index: genomIndex,
+          shift_index: shiftIndex,
+          shift_in_at: shiftInAt,
+          workrole_id: workroleId,
+        },
+        dataType: 'json'
+      })
+      .done(function(genomInfo){
+        targetCell[0].dataset.workroleId = genomInfo.workrole_id
+        changeWorkRoleColer(targetCell)
+      })
+      .fail(function(){
+
+      })
     });
   }
 })

--- a/app/assets/javascripts/shift_data_color.js
+++ b/app/assets/javascripts/shift_data_color.js
@@ -18,7 +18,7 @@ $(function(){
       return array;
     }
 
-    // 色変え関数
+    // 色変え関数。要素を1つ受け取って動くように修正した。
     function changeWorkRoleColer(cell) {
       // jQueryのdata()はキャッシュされるためJSのdatasetを使う
       const workrole_id = Number(cell[0].dataset.workroleId);
@@ -63,8 +63,23 @@ $(function(){
         dataType: 'json'
       })
       .done(function(genomInfo){
-        targetCell[0].dataset.workroleId = genomInfo.workrole_id
+        // クリックした要素のdata-workrole-idを更新する
+        targetCell[0].dataset.workroleId = genomInfo.after_role
+        // 色変え関数にクリックした要素を渡す
         changeWorkRoleColer(targetCell)
+        // 元のroleの合計リソース欄を書き換え、不足になったら赤表示用のclassをつける
+        const beforeRoleCell = $(`td[data-resource-type=sum][data-genom-index=${genomInfo.genom_index}][data-workrole-id=${genomInfo.before_role}][data-time=${genomInfo.shift_in_at}]`)
+        const beforeReqCount = Number($(`td[data-resource-type=req][data-genom-index=${genomInfo.genom_index}][data-workrole-id=${genomInfo.before_role}][data-time=${genomInfo.shift_in_at}]`).text())
+        const beforeRoleCount = Number(beforeRoleCell.text()) - 1
+        beforeRoleCell.text(beforeRoleCount)
+        if (beforeRoleCount < beforeReqCount) { beforeRoleCell.addClass("not_enough_resource") }
+
+        // 変更後のroleの合計リソース欄を書き換え、不足が解消したら赤表示用のclassを外す
+        const afterRoleCell = $(`td[data-resource-type=sum][data-genom-index=${genomInfo.genom_index}][data-workrole-id=${genomInfo.after_role}][data-time=${genomInfo.shift_in_at}]`)
+        const afterReqCount = Number($(`td[data-resource-type=req][data-genom-index=${genomInfo.genom_index}][data-workrole-id=${genomInfo.after_role}][data-time=${genomInfo.shift_in_at}]`).text())
+        const afterRoleCount = Number(afterRoleCell.text()) + 1
+        afterRoleCell.text(afterRoleCount)
+        if (afterRoleCount === afterReqCount) { afterRoleCell.removeClass("not_enough_resource") }
       })
       .fail(function(){
 

--- a/app/controllers/api/shift_generators_controller.rb
+++ b/app/controllers/api/shift_generators_controller.rb
@@ -4,11 +4,30 @@ class Api::ShiftGeneratorsController < ApplicationController
     if user_signed_in? && current_user.admin?
       users = User.where(role: "employee").includes(:attendances)
       @workroles = WorkRole.all
-      sgg = ShiftGeneticGenerator.new(users, @workroles)
-      @genoms = sgg.generate(period_params)
+      # sgg = ShiftGeneticGenerator.new(users, @workroles)
+      # @genoms = sgg.generate(period_params)
+      @genoms = test_genoms
+      @@genoms = test_genoms
+      # session[:genoms] = test_genoms
     else
       redirect_to root_path
     end
+  end
+
+  def create
+    binding.pry
+  end
+
+  def update
+    next_role = params[:workrole_id].to_i + 1
+    @@genoms[params[:genom_index].to_i][:shifts][params[:shift_index].to_i][:array][params[:shift_in_at].to_i] = next_role
+    @genom_info = {
+      genom_index: params[:genom_index],
+      shift_index: params[:shift_index],
+      shift_in_at: params[:shift_in_at],
+    }
+    @genom_info[:workrole_id] = WorkRole.count < next_role ? 0 : next_role
+    render :update, formats: :json
   end
 
   private
@@ -17,4 +36,135 @@ class Api::ShiftGeneratorsController < ApplicationController
     @period = params.permit(:start, :finish)
   end
 
+  def test_genoms
+    [
+      {:this_day=>DateTime.new(2020,2,1),
+       :required=>
+        [{:workrole=>{:id=>1, :name=>"Bernhard and Sons"}, :array=>[9, 0, 1, 1, 1, 1, 2, 3, 3, 0, 0, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 9, 9]},
+         {:workrole=>{:id=>2, :name=>"Kassulke Inc"}, :array=>[5, 5, 6, 6, 7, 7, 7, 8, 8, 9, 9, 9, 0, 0, 1, 1, 1, 2, 2, 3, 3, 0, 0, 0]},
+         {:workrole=>{:id=>3, :name=>"Gleichner, Fisher and Brekke"}, :array=>[6, 6, 7, 7, 9, 9, 9, 0, 0, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 0, 0, 0, 6]},
+        ],
+       :sum=>
+        [{:workrole=>{:id=>1, :name=>"Bernhard and Sons"}, :array=>[0, 0, 1, 1, 1, 1, 2, 3, 3, 0, 0, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 6, 0]},
+         {:workrole=>{:id=>2, :name=>"Kassulke Inc"}, :array=>[0, 5, 5, 6, 7, 7, 7, 8, 8, 9, 9, 9, 0, 0, 1, 1, 1, 2, 2, 3, 3, 0, 0, 0]},
+         {:workrole=>{:id=>3, :name=>"Gleichner, Fisher and Brekke"}, :array=>[0, 0, 0, 0, 0, 0, 7, 0, 0, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 2, 0, 0, 0]},
+        ],
+       :shifts=>
+        [{:user_id=>2, :array=>[nil, nil, nil, nil, nil, nil, 3, 2, 2, 2, 1, 2, 0, 0, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.7777777777777778},
+         {:user_id=>3, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 2, 2, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>4, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 3, 0, 1, 0, 3, 0, 3, nil, nil, nil, nil], :evaluation=>0.7102857102857103},
+         {:user_id=>5, :array=>[nil, nil, nil, 3, 3, 2, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>6, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 2, nil, nil, nil], :evaluation=>0.8333333333333330},
+         {:user_id=>7, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 2, 0, 1, 1, 3, 0, 2, 0, 1, 1, 1, nil, nil], :evaluation=>0.7272727272727273},
+         {:user_id=>8, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 3, 3, 1, 1, nil], :evaluation=>1.0},
+         {:user_id=>9, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 2, 1, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>10, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 1, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>11, :array=>[nil, nil, nil, nil, nil, nil, 3, 1, 1, 2, 2, 0, 3, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.8571028571028571},
+         {:user_id=>12, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 3, 1, 1, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>13, :array=>[nil, nil, 2, 2, 2, 2, 2, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>14, :array=>[1, 2, 2, 3, 3, 3, 3, 1, 0, 2, 1, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
+         {:user_id=>15, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 1, 2, 2, 2, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>16, :array=>[nil, nil, nil, 3, 2, 3, 3, 2, 2, 0, 0, 2, 0, 0, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
+         {:user_id=>17, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 1, 0, 0, 3, 1, nil, nil, nil, nil], :evaluation=>0.8571028571028571},
+         {:user_id=>18, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>19, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 0, 0, 2, 0, 1, 0, 2, 2, 1, 1, nil], :evaluation=>0.7},
+         {:user_id=>20, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>21, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 1, 1, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>22, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 1, 1, 1, nil], :evaluation=>1.0},
+         {:user_id=>23, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>24, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 1, 1, 1, 1, nil], :evaluation=>0.9230769230769231},
+         {:user_id=>25, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>26, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>27, :array=>[1, 2, 2, 1, 1, 3, 2, 2, 1, 1, 0, 0, 1, 0, 0, 0, 3, 1, 1, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
+         {:user_id=>28, :array=>[nil, nil, nil, nil, nil, nil, 3, 0, 2, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 3, nil, nil, nil], :evaluation=>0.7102857102857103},
+         {:user_id=>29, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 1, 0, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>30, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 2, 3, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
+         {:user_id=>31, :array=>[nil, nil, nil, 2, 3, 2, 2, 0, 2, 0, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
+         {:user_id=>32, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>33, :array=>[nil, nil, nil, nil, nil, nil, nil, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 3, 1, 1, 1, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>34, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 0, 0, 0, 1, 3, 0, 1, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
+         {:user_id=>35, :array=>[nil, nil, nil, nil, nil, nil, 3, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>36, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>37, :array=>[1, 2, 1, 2, 3, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 3, 1, 0, nil, nil, nil, nil, nil, nil], :evaluation=>0.7058823529011765},
+         {:user_id=>38, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 3, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil], :evaluation=>0.8},
+         {:user_id=>39, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 3, 2, 0, 0, 0, 0, 0, 0, 3, 3, 1, nil, nil, nil], :evaluation=>0.8333333333333330},
+         {:user_id=>40, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 1, 1, 1, 1, 1, nil], :evaluation=>1.0},
+         {:user_id=>41, :array=>[nil, nil, nil, nil, nil, 2, 3, 2, 2, 0, 0, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
+         {:user_id=>42, :array=>[nil, nil, nil, nil, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>43, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 1, 1, 0, 1, 1, 1, nil, nil], :evaluation=>0.8571028571028571},
+         {:user_id=>44, :array=>[nil, nil, nil, 2, 2, 3, 2, 2, 0, 2, 0, 1, 0, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.7},
+         {:user_id=>45, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 0, 0, 1, 2, 1, 1, nil, nil], :evaluation=>0.7272727272727273},
+         {:user_id=>46, :array=>[nil, 2, 2, 3, 2, 1, 2, 2, 2, 0, 2, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6363636363636360},
+         {:user_id=>47, :array=>[1, 2, 2, 2, 2, 2, 2, 0, 1, 1, 2, 2, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.8061538061538061},
+         {:user_id=>48, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 0, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>49, :array=>[nil, nil, nil, 2, 2, 2, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+         {:user_id=>50, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, nil], :evaluation=>1.0},
+         {:user_id=>51, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0}],
+       :evaluation=>0.8802093331505096},
+       {:this_day=>DateTime.new(2020,2,2),
+        :required=>
+         [{:workrole=>{:id=>1, :name=>"Bernhard and Sons"}, :array=>[9, 0, 1, 1, 1, 1, 2, 3, 3, 0, 0, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 9, 9]},
+          {:workrole=>{:id=>2, :name=>"Kassulke Inc"}, :array=>[5, 5, 6, 6, 7, 7, 7, 8, 8, 9, 9, 9, 0, 0, 1, 1, 1, 2, 2, 3, 3, 0, 0, 0]},
+          {:workrole=>{:id=>3, :name=>"Gleichner, Fisher and Brekke"}, :array=>[6, 6, 7, 7, 9, 9, 9, 0, 0, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 0, 0, 0, 6]},
+        ],
+        :sum=>
+         [{:workrole=>{:id=>1, :name=>"Bernhard and Sons"}, :array=>[0, 0, 1, 1, 1, 1, 2, 3, 3, 0, 0, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 6, 0]},
+          {:workrole=>{:id=>2, :name=>"Kassulke Inc"}, :array=>[0, 5, 5, 6, 7, 7, 7, 8, 8, 9, 9, 9, 0, 0, 1, 1, 1, 2, 2, 3, 3, 0, 0, 0]},
+          {:workrole=>{:id=>3, :name=>"Gleichner, Fisher and Brekke"}, :array=>[0, 0, 0, 0, 0, 0, 7, 0, 0, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 2, 0, 0, 0]},
+        ],
+        :shifts=>
+         [{:user_id=>2, :array=>[nil, nil, nil, nil, nil, nil, 3, 2, 2, 2, 1, 2, 0, 0, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.7777777777777778},
+          {:user_id=>3, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 2, 2, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>4, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 3, 0, 1, 0, 3, 0, 3, nil, nil, nil, nil], :evaluation=>0.7102857102857103},
+          {:user_id=>5, :array=>[nil, nil, nil, 3, 3, 2, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>6, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 2, nil, nil, nil], :evaluation=>0.8333333333333330},
+          {:user_id=>7, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 2, 0, 1, 1, 3, 0, 2, 0, 1, 1, 1, nil, nil], :evaluation=>0.7272727272727273},
+          {:user_id=>8, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 3, 3, 1, 1, nil], :evaluation=>1.0},
+          {:user_id=>9, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 2, 1, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>10, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 1, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>11, :array=>[nil, nil, nil, nil, nil, nil, 3, 1, 1, 2, 2, 0, 3, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.8571028571028571},
+          {:user_id=>12, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 3, 1, 1, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>13, :array=>[nil, nil, 2, 2, 2, 2, 2, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>14, :array=>[1, 2, 2, 3, 3, 3, 3, 1, 0, 2, 1, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
+          {:user_id=>15, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 1, 2, 2, 2, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>16, :array=>[nil, nil, nil, 3, 2, 3, 3, 2, 2, 0, 0, 2, 0, 0, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
+          {:user_id=>17, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 1, 0, 0, 3, 1, nil, nil, nil, nil], :evaluation=>0.8571028571028571},
+          {:user_id=>18, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>19, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 0, 0, 2, 0, 1, 0, 2, 2, 1, 1, nil], :evaluation=>0.7},
+          {:user_id=>20, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>21, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 1, 1, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>22, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 1, 1, 1, nil], :evaluation=>1.0},
+          {:user_id=>23, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>24, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 1, 1, 1, 1, nil], :evaluation=>0.9230769230769231},
+          {:user_id=>25, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>26, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>27, :array=>[1, 2, 2, 1, 1, 3, 2, 2, 1, 1, 0, 0, 1, 0, 0, 0, 3, 1, 1, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
+          {:user_id=>28, :array=>[nil, nil, nil, nil, nil, nil, 3, 0, 2, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 3, nil, nil, nil], :evaluation=>0.7102857102857103},
+          {:user_id=>29, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 1, 0, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>30, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 2, 3, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
+          {:user_id=>31, :array=>[nil, nil, nil, 2, 3, 2, 2, 0, 2, 0, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
+          {:user_id=>32, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>33, :array=>[nil, nil, nil, nil, nil, nil, nil, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 3, 1, 1, 1, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>34, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 0, 0, 0, 1, 3, 0, 1, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
+          {:user_id=>35, :array=>[nil, nil, nil, nil, nil, nil, 3, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>36, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>37, :array=>[1, 2, 1, 2, 3, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 3, 1, 0, nil, nil, nil, nil, nil, nil], :evaluation=>0.7058823529011765},
+          {:user_id=>38, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 3, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil], :evaluation=>0.8},
+          {:user_id=>39, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 3, 2, 0, 0, 0, 0, 0, 0, 3, 3, 1, nil, nil, nil], :evaluation=>0.8333333333333330},
+          {:user_id=>40, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 1, 1, 1, 1, 1, nil], :evaluation=>1.0},
+          {:user_id=>41, :array=>[nil, nil, nil, nil, nil, 2, 3, 2, 2, 0, 0, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
+          {:user_id=>42, :array=>[nil, nil, nil, nil, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>43, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 1, 1, 0, 1, 1, 1, nil, nil], :evaluation=>0.8571028571028571},
+          {:user_id=>44, :array=>[nil, nil, nil, 2, 2, 3, 2, 2, 0, 2, 0, 1, 0, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.7},
+          {:user_id=>45, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 0, 0, 1, 2, 1, 1, nil, nil], :evaluation=>0.7272727272727273},
+          {:user_id=>46, :array=>[nil, 2, 2, 3, 2, 1, 2, 2, 2, 0, 2, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6363636363636360},
+          {:user_id=>47, :array=>[1, 2, 2, 2, 2, 2, 2, 0, 1, 1, 2, 2, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.8061538061538061},
+          {:user_id=>48, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 0, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>49, :array=>[nil, nil, nil, 2, 2, 2, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
+          {:user_id=>50, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, nil], :evaluation=>1.0},
+          {:user_id=>51, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0}],
+        :evaluation=>0.8802093331505096
+      }
+    ]
+  end
 end

--- a/app/controllers/api/shift_generators_controller.rb
+++ b/app/controllers/api/shift_generators_controller.rb
@@ -1,32 +1,43 @@
 class Api::ShiftGeneratorsController < ApplicationController
 
+  @@genoms = []
+
   def show
     if user_signed_in? && current_user.admin?
       users = User.where(role: "employee").includes(:attendances)
       @workroles = WorkRole.all
-      # sgg = ShiftGeneticGenerator.new(users, @workroles)
-      # @genoms = sgg.generate(period_params)
-      @genoms = test_genoms
-      @@genoms = test_genoms
-      # session[:genoms] = test_genoms
+      sgg = ShiftGeneticGenerator.new(users, @workroles)
+      @genoms = sgg.generate(period_params)
+      @@genoms = @genoms
     else
       redirect_to root_path
     end
   end
 
   def create
-    binding.pry
+    shifts = Shift.build_from_genoms(@@genoms)
+    # TODO バルクインサート時のエラーハンドリング処理
+    if true
+      Shift.import! shifts
+      redirect_to root_path
+    else
+      @workroles = WorkRole.all
+      @genoms = @@genoms
+      render :show
+    end
   end
 
   def update
-    next_role = params[:workrole_id].to_i + 1
-    @@genoms[params[:genom_index].to_i][:shifts][params[:shift_index].to_i][:array][params[:shift_in_at].to_i] = next_role
+    # 今のworkroleに+1したものが存在すれば+1したものを、無ければ0(アサイン無し)をafter_roleとする
+    after_role = WorkRole.ids.include?(params[:workrole_id].to_i + 1) ? params[:workrole_id].to_i + 1 : 0
+    # クリックされたgenomsを特定し、after_roleで更新する
+    @@genoms[params[:genom_index].to_i][:shifts][params[:shift_index].to_i][:array][params[:shift_in_at].to_i] = after_role
     @genom_info = {
       genom_index: params[:genom_index],
-      shift_index: params[:shift_index],
       shift_in_at: params[:shift_in_at],
+      before_role: params[:workrole_id],
+      after_role: after_role
     }
-    @genom_info[:workrole_id] = WorkRole.count < next_role ? 0 : next_role
     render :update, formats: :json
   end
 
@@ -36,135 +47,4 @@ class Api::ShiftGeneratorsController < ApplicationController
     @period = params.permit(:start, :finish)
   end
 
-  def test_genoms
-    [
-      {:this_day=>DateTime.new(2020,2,1),
-       :required=>
-        [{:workrole=>{:id=>1, :name=>"Bernhard and Sons"}, :array=>[9, 0, 1, 1, 1, 1, 2, 3, 3, 0, 0, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 9, 9]},
-         {:workrole=>{:id=>2, :name=>"Kassulke Inc"}, :array=>[5, 5, 6, 6, 7, 7, 7, 8, 8, 9, 9, 9, 0, 0, 1, 1, 1, 2, 2, 3, 3, 0, 0, 0]},
-         {:workrole=>{:id=>3, :name=>"Gleichner, Fisher and Brekke"}, :array=>[6, 6, 7, 7, 9, 9, 9, 0, 0, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 0, 0, 0, 6]},
-        ],
-       :sum=>
-        [{:workrole=>{:id=>1, :name=>"Bernhard and Sons"}, :array=>[0, 0, 1, 1, 1, 1, 2, 3, 3, 0, 0, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 6, 0]},
-         {:workrole=>{:id=>2, :name=>"Kassulke Inc"}, :array=>[0, 5, 5, 6, 7, 7, 7, 8, 8, 9, 9, 9, 0, 0, 1, 1, 1, 2, 2, 3, 3, 0, 0, 0]},
-         {:workrole=>{:id=>3, :name=>"Gleichner, Fisher and Brekke"}, :array=>[0, 0, 0, 0, 0, 0, 7, 0, 0, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 2, 0, 0, 0]},
-        ],
-       :shifts=>
-        [{:user_id=>2, :array=>[nil, nil, nil, nil, nil, nil, 3, 2, 2, 2, 1, 2, 0, 0, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.7777777777777778},
-         {:user_id=>3, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 2, 2, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>4, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 3, 0, 1, 0, 3, 0, 3, nil, nil, nil, nil], :evaluation=>0.7102857102857103},
-         {:user_id=>5, :array=>[nil, nil, nil, 3, 3, 2, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>6, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 2, nil, nil, nil], :evaluation=>0.8333333333333330},
-         {:user_id=>7, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 2, 0, 1, 1, 3, 0, 2, 0, 1, 1, 1, nil, nil], :evaluation=>0.7272727272727273},
-         {:user_id=>8, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 3, 3, 1, 1, nil], :evaluation=>1.0},
-         {:user_id=>9, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 2, 1, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>10, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 1, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>11, :array=>[nil, nil, nil, nil, nil, nil, 3, 1, 1, 2, 2, 0, 3, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.8571028571028571},
-         {:user_id=>12, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 3, 1, 1, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>13, :array=>[nil, nil, 2, 2, 2, 2, 2, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>14, :array=>[1, 2, 2, 3, 3, 3, 3, 1, 0, 2, 1, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
-         {:user_id=>15, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 1, 2, 2, 2, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>16, :array=>[nil, nil, nil, 3, 2, 3, 3, 2, 2, 0, 0, 2, 0, 0, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
-         {:user_id=>17, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 1, 0, 0, 3, 1, nil, nil, nil, nil], :evaluation=>0.8571028571028571},
-         {:user_id=>18, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>19, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 0, 0, 2, 0, 1, 0, 2, 2, 1, 1, nil], :evaluation=>0.7},
-         {:user_id=>20, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>21, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 1, 1, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>22, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 1, 1, 1, nil], :evaluation=>1.0},
-         {:user_id=>23, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>24, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 1, 1, 1, 1, nil], :evaluation=>0.9230769230769231},
-         {:user_id=>25, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>26, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>27, :array=>[1, 2, 2, 1, 1, 3, 2, 2, 1, 1, 0, 0, 1, 0, 0, 0, 3, 1, 1, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
-         {:user_id=>28, :array=>[nil, nil, nil, nil, nil, nil, 3, 0, 2, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 3, nil, nil, nil], :evaluation=>0.7102857102857103},
-         {:user_id=>29, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 1, 0, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>30, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 2, 3, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
-         {:user_id=>31, :array=>[nil, nil, nil, 2, 3, 2, 2, 0, 2, 0, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
-         {:user_id=>32, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>33, :array=>[nil, nil, nil, nil, nil, nil, nil, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 3, 1, 1, 1, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>34, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 0, 0, 0, 1, 3, 0, 1, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
-         {:user_id=>35, :array=>[nil, nil, nil, nil, nil, nil, 3, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>36, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>37, :array=>[1, 2, 1, 2, 3, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 3, 1, 0, nil, nil, nil, nil, nil, nil], :evaluation=>0.7058823529011765},
-         {:user_id=>38, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 3, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil], :evaluation=>0.8},
-         {:user_id=>39, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 3, 2, 0, 0, 0, 0, 0, 0, 3, 3, 1, nil, nil, nil], :evaluation=>0.8333333333333330},
-         {:user_id=>40, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 1, 1, 1, 1, 1, nil], :evaluation=>1.0},
-         {:user_id=>41, :array=>[nil, nil, nil, nil, nil, 2, 3, 2, 2, 0, 0, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
-         {:user_id=>42, :array=>[nil, nil, nil, nil, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>43, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 1, 1, 0, 1, 1, 1, nil, nil], :evaluation=>0.8571028571028571},
-         {:user_id=>44, :array=>[nil, nil, nil, 2, 2, 3, 2, 2, 0, 2, 0, 1, 0, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.7},
-         {:user_id=>45, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 0, 0, 1, 2, 1, 1, nil, nil], :evaluation=>0.7272727272727273},
-         {:user_id=>46, :array=>[nil, 2, 2, 3, 2, 1, 2, 2, 2, 0, 2, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6363636363636360},
-         {:user_id=>47, :array=>[1, 2, 2, 2, 2, 2, 2, 0, 1, 1, 2, 2, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.8061538061538061},
-         {:user_id=>48, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 0, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>49, :array=>[nil, nil, nil, 2, 2, 2, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-         {:user_id=>50, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, nil], :evaluation=>1.0},
-         {:user_id=>51, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0}],
-       :evaluation=>0.8802093331505096},
-       {:this_day=>DateTime.new(2020,2,2),
-        :required=>
-         [{:workrole=>{:id=>1, :name=>"Bernhard and Sons"}, :array=>[9, 0, 1, 1, 1, 1, 2, 3, 3, 0, 0, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 9, 9]},
-          {:workrole=>{:id=>2, :name=>"Kassulke Inc"}, :array=>[5, 5, 6, 6, 7, 7, 7, 8, 8, 9, 9, 9, 0, 0, 1, 1, 1, 2, 2, 3, 3, 0, 0, 0]},
-          {:workrole=>{:id=>3, :name=>"Gleichner, Fisher and Brekke"}, :array=>[6, 6, 7, 7, 9, 9, 9, 0, 0, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 0, 0, 0, 6]},
-        ],
-        :sum=>
-         [{:workrole=>{:id=>1, :name=>"Bernhard and Sons"}, :array=>[0, 0, 1, 1, 1, 1, 2, 3, 3, 0, 0, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 6, 0]},
-          {:workrole=>{:id=>2, :name=>"Kassulke Inc"}, :array=>[0, 5, 5, 6, 7, 7, 7, 8, 8, 9, 9, 9, 0, 0, 1, 1, 1, 2, 2, 3, 3, 0, 0, 0]},
-          {:workrole=>{:id=>3, :name=>"Gleichner, Fisher and Brekke"}, :array=>[0, 0, 0, 0, 0, 0, 7, 0, 0, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 2, 0, 0, 0]},
-        ],
-        :shifts=>
-         [{:user_id=>2, :array=>[nil, nil, nil, nil, nil, nil, 3, 2, 2, 2, 1, 2, 0, 0, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.7777777777777778},
-          {:user_id=>3, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 2, 2, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>4, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 3, 0, 1, 0, 3, 0, 3, nil, nil, nil, nil], :evaluation=>0.7102857102857103},
-          {:user_id=>5, :array=>[nil, nil, nil, 3, 3, 2, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>6, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 2, nil, nil, nil], :evaluation=>0.8333333333333330},
-          {:user_id=>7, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 2, 0, 1, 1, 3, 0, 2, 0, 1, 1, 1, nil, nil], :evaluation=>0.7272727272727273},
-          {:user_id=>8, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 3, 3, 1, 1, nil], :evaluation=>1.0},
-          {:user_id=>9, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 2, 1, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>10, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 1, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>11, :array=>[nil, nil, nil, nil, nil, nil, 3, 1, 1, 2, 2, 0, 3, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.8571028571028571},
-          {:user_id=>12, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 3, 1, 1, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>13, :array=>[nil, nil, 2, 2, 2, 2, 2, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>14, :array=>[1, 2, 2, 3, 3, 3, 3, 1, 0, 2, 1, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
-          {:user_id=>15, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 1, 2, 2, 2, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>16, :array=>[nil, nil, nil, 3, 2, 3, 3, 2, 2, 0, 0, 2, 0, 0, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
-          {:user_id=>17, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 1, 0, 0, 3, 1, nil, nil, nil, nil], :evaluation=>0.8571028571028571},
-          {:user_id=>18, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>19, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 0, 0, 2, 0, 1, 0, 2, 2, 1, 1, nil], :evaluation=>0.7},
-          {:user_id=>20, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>21, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 1, 1, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>22, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 1, 1, 1, nil], :evaluation=>1.0},
-          {:user_id=>23, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>24, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 1, 1, 1, 1, nil], :evaluation=>0.9230769230769231},
-          {:user_id=>25, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>26, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>27, :array=>[1, 2, 2, 1, 1, 3, 2, 2, 1, 1, 0, 0, 1, 0, 0, 0, 3, 1, 1, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
-          {:user_id=>28, :array=>[nil, nil, nil, nil, nil, nil, 3, 0, 2, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 3, nil, nil, nil], :evaluation=>0.7102857102857103},
-          {:user_id=>29, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 0, 1, 0, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>30, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, 3, 2, 3, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
-          {:user_id=>31, :array=>[nil, nil, nil, 2, 3, 2, 2, 0, 2, 0, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
-          {:user_id=>32, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>33, :array=>[nil, nil, nil, nil, nil, nil, nil, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 3, 1, 1, 1, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>34, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 0, 0, 0, 1, 3, 0, 1, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.75},
-          {:user_id=>35, :array=>[nil, nil, nil, nil, nil, nil, 3, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>36, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>37, :array=>[1, 2, 1, 2, 3, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 3, 1, 0, nil, nil, nil, nil, nil, nil], :evaluation=>0.7058823529011765},
-          {:user_id=>38, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 3, 0, 0, 0, 3, nil, nil, nil, nil, nil, nil], :evaluation=>0.8},
-          {:user_id=>39, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, 0, 2, 3, 2, 0, 0, 0, 0, 0, 0, 3, 3, 1, nil, nil, nil], :evaluation=>0.8333333333333330},
-          {:user_id=>40, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, 1, 1, 1, 1, 1, nil], :evaluation=>1.0},
-          {:user_id=>41, :array=>[nil, nil, nil, nil, nil, 2, 3, 2, 2, 0, 0, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6666666666666666},
-          {:user_id=>42, :array=>[nil, nil, nil, nil, 2, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>43, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 1, 1, 1, 0, 1, 1, 1, nil, nil], :evaluation=>0.8571028571028571},
-          {:user_id=>44, :array=>[nil, nil, nil, 2, 2, 3, 2, 2, 0, 2, 0, 1, 0, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.7},
-          {:user_id=>45, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 0, 0, 1, 2, 1, 1, nil, nil], :evaluation=>0.7272727272727273},
-          {:user_id=>46, :array=>[nil, 2, 2, 3, 2, 1, 2, 2, 2, 0, 2, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.6363636363636360},
-          {:user_id=>47, :array=>[1, 2, 2, 2, 2, 2, 2, 0, 1, 1, 2, 2, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>0.8061538061538061},
-          {:user_id=>48, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 2, 0, 0, 0, 0, 0, 0, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>49, :array=>[nil, nil, nil, 2, 2, 2, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0},
-          {:user_id=>50, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1, nil], :evaluation=>1.0},
-          {:user_id=>51, :array=>[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], :evaluation=>1.0}],
-        :evaluation=>0.8802093331505096
-      }
-    ]
-  end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -53,7 +53,7 @@ class Shift < ApplicationRecord
           end
         end
       end
-      shift_instances
+      shift_instances.flatten
     end
   end
 end

--- a/app/views/api/shift_generators/show.html.haml
+++ b/app/views/api/shift_generators/show.html.haml
@@ -1,5 +1,5 @@
 = link_to 'トップページ', root_path
-= button_to 'シフトを確定する'
+= button_to 'シフトを確定する', api_shift_generator_path
 %section.shift_api_create_page
   %h1.page_title シフト一覧
   %ul.workrole-example_lists
@@ -9,7 +9,7 @@
   .shift-tables.shift-slick_container{data: {workrole: {ids: WorkRole.ids}}}
     - @genoms.each_with_index do |genom, genom_index|
       .shift-table{data: {date: genom[:this_day].strftime("%Y/%m/%d")}}
-        %h1{data: {date: {time: genom[:this_day]}}}
+        %h1
           = genom[:this_day].strftime("%Y/%m/%d")
         %table
           %tr
@@ -43,7 +43,7 @@
                 = req[:workrole][:name]
               - req[:array].each_with_index do |data,i|
                 - if i >= 8 && i <= 24
-                  %td{data:{resource_type: "req", workrole: {id: req[:workrole][:id]}, time: i}}
+                  %td{data:{resource_type: "req", workrole: {id: req[:workrole][:id]}, time: i, genom: {index: genom_index}}}
                     = data
                 - else
                   %td.hidden{data:{resource_type: "req", workrole: {id: req[:workrole][:id]}, time: i}}
@@ -57,7 +57,7 @@
                 = sum[:workrole][:name]
               - sum[:array].each_with_index do |data,i|
                 - if i >= 8 && i <= 24
-                  %td{data:{resource_type: "sum", workrole: {id: sum[:workrole][:id]}, time: i}}
+                  %td{data:{resource_type: "sum", time: i, workrole: {id: sum[:workrole][:id]}, genom: {index: genom_index}}}
                     = data
                 - else
                   %td.hidden{data:{resource_type: "sum", workrole: {id: sum[:workrole][:id]}, time: i}}

--- a/app/views/api/shift_generators/show.html.haml
+++ b/app/views/api/shift_generators/show.html.haml
@@ -1,4 +1,5 @@
 = link_to 'トップページ', root_path
+= button_to 'シフトを確定する'
 %section.shift_api_create_page
   %h1.page_title シフト一覧
   %ul.workrole-example_lists
@@ -6,9 +7,9 @@
       %li.color_shift-data{data: {workrole: {id: workrole.id}}}
         = workrole.name
   .shift-tables.shift-slick_container{data: {workrole: {ids: WorkRole.ids}}}
-    - @genoms.each do |genom|
+    - @genoms.each_with_index do |genom, genom_index|
       .shift-table{data: {date: genom[:this_day].strftime("%Y/%m/%d")}}
-        %h
+        %h1{data: {date: {time: genom[:this_day]}}}
           = genom[:this_day].strftime("%Y/%m/%d")
         %table
           %tr
@@ -20,14 +21,14 @@
               - else
                 %th.hidden
                   = d
-          - genom[:shifts].each do |shift|
+          - genom[:shifts].each_with_index do |shift, shift_index|
             %tr
               %td
                 = shift[:user_name]
-              - shift[:array].each_with_index do |is_shift, i|
-                - if i >= 8 && i <= 24
+              - shift[:array].each_with_index do |is_shift, shift_in_at|
+                - if shift_in_at >= 8 && shift_in_at <= 24
                   - if is_shift
-                    %td.color_shift-data{data: {workrole: {id: is_shift}}}
+                    %td.color_shift-data{data: {workrole: {id: is_shift},genom_index: genom_index,shift_index: shift_index,shift_in_at: shift_in_at}}
                   - else
                     %td
                 - else

--- a/app/views/api/shift_generators/update.json.jbuilder
+++ b/app/views/api/shift_generators/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @genom_info, :shift_in_at, :workrole_id
+json.extract! @genom_info, :genom_index, :shift_in_at, :before_role, :after_role

--- a/app/views/api/shift_generators/update.json.jbuilder
+++ b/app/views/api/shift_generators/update.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @genom_info, :shift_in_at, :workrole_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   devise_for :users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   namespace :api do
-    resource :shift_generator, only: :show
+    resource :shift_generator, only: [:show, :create, :update]
   end
 end


### PR DESCRIPTION
# What
- genomsを表示している画面からajaxで更新できるようにした
- シフト確定ボタンを押すことで更新したgenomsからShiftのレコードを作成できるようにした

# Why
- 生成されたシフトを確定前に担当者が調整できる必要があるため

# 影響範囲
- ユーザへの影響(メリット・デメリット)
  - adminユーザーはシフト生成→確認→調整→シフト確定と作業できるようになった。
- 開発側への影響(メリット・デメリット)
  - `Api::ShiftGeneratorsController`で`@@genoms`というクラス変数を使うようになりました。
- その他コードへの影響

# 使い方、確認の仕方、テストの仕方
- 使い方の説明
  - admin権限のユーザーでログインした状態で`/admin/shifts`へアクセスする。
  - シフト作成期間を入力し、Saveボタンを押す。
  - 仮シフトが表示され、シフトが表示されているセルをクリックすると別のworkroleへのシフトへ変更することができる
  - 「シフトを確定する」ボタンを押すと、表示されている状態のシフトのレコードが作成される。
- 再現手順等 

# 注意事項
- 注意

# テスト結果とテスト項目
## テストコード実装済み
- [x] テストする際の項目を、このように、チェック可能な形式で記載する。

## 目視確認
- [ ] テストする際の項目を、このように、チェック可能な形式で記載する。

# TODOと保留
- TODO
  - shiftインスタンスをバルクインサートで作成しているが、エラーハンドリングができていない。
- 保留項目
  - ShiftGeneticGeneratorのgenerateメソッドが返すgenomの日付が、シフト作成期間の初日で固定されている？

# その他
